### PR TITLE
[#4]: Match games not updating

### DIFF
--- a/brackets-prisma-db/src/storage-handlers/update-handlers/match-game.ts
+++ b/brackets-prisma-db/src/storage-handlers/update-handlers/match-game.ts
@@ -95,9 +95,9 @@ export async function handleMatchGameUpdate(
             },
         })
         .then((games) => {
-            return Promise.all([
+            return Promise.all(
                 games.map((game) => updateById(prisma, game.id, value)),
-            ]);
+            );
         })
         .then(() => true)
         .catch(() => false);

--- a/brackets-prisma-db/src/storage-handlers/update-handlers/match.ts
+++ b/brackets-prisma-db/src/storage-handlers/update-handlers/match.ts
@@ -95,9 +95,9 @@ export async function handleMatchUpdate(
             },
         })
         .then((matches) => {
-            return Promise.all([
+            return Promise.all(
                 matches.map((match) => updateById(prisma, match.id, value)),
-            ]);
+            );
         })
         .then(() => true)
         .catch(() => false);


### PR DESCRIPTION
The Issue was that instead of passing the array of Promises to `Promise.all` instead an `Array<Array<Promise>>` was passed.

Same has been fixed for the `Match` implementation due to the similarities.

Closes #4