### PR TITLE
fix(prisma-db): Final Standings in wrong order

### DIFF
--- a/brackets-prisma-db/src/storage-handlers/select-handlers/group.ts
+++ b/brackets-prisma-db/src/storage-handlers/select-handlers/group.ts
@@ -9,7 +9,9 @@ export async function handleGroupSelect(
     if (filter === undefined) {
         // Query all entries of table
         return prisma.group
-            .findMany()
+            .findMany({
+                orderBy: [{ number: 'asc' }],
+            })
             .then((values) => values.map(GroupTransformer.from))
             .catch(() => []);
     }
@@ -37,6 +39,7 @@ export async function handleGroupSelect(
                 stageId: filter.stage_id,
                 number: filter.number,
             },
+            orderBy: [{ number: 'asc' }],
         })
         .then((values) => values.map(GroupTransformer.from))
         .catch(() => []);

--- a/brackets-prisma-db/src/storage-handlers/select-handlers/match-game.ts
+++ b/brackets-prisma-db/src/storage-handlers/select-handlers/match-game.ts
@@ -17,6 +17,7 @@ export async function handleMatchGameSelect(
                     opponent1Result: true,
                     opponent2Result: true,
                 },
+                orderBy: [{ number: 'asc' }],
             })
             .then((values) => values.map(MatchGameTransformer.from))
             .catch(() => []);
@@ -57,6 +58,7 @@ export async function handleMatchGameSelect(
                 opponent1Result: true,
                 opponent2Result: true,
             },
+            orderBy: [{ number: 'asc' }],
         })
         .then((values) => values.map(MatchGameTransformer.from))
         .catch(() => []);

--- a/brackets-prisma-db/src/storage-handlers/select-handlers/match.ts
+++ b/brackets-prisma-db/src/storage-handlers/select-handlers/match.ts
@@ -14,6 +14,14 @@ export async function handleMatchSelect(
                     opponent1Result: true,
                     opponent2Result: true,
                 },
+                orderBy: [
+                    {
+                        round: {
+                            number: 'asc',
+                        },
+                    },
+                    { number: 'asc' },
+                ],
             })
             .then((values) => values.map(MatchTransformer.from))
             .catch(() => []);
@@ -56,6 +64,14 @@ export async function handleMatchSelect(
                 opponent1Result: true,
                 opponent2Result: true,
             },
+            orderBy: [
+                {
+                    round: {
+                        number: 'asc',
+                    },
+                },
+                { number: 'asc' },
+            ],
         })
         .then((values) => values.map(MatchTransformer.from))
         .catch(() => []);

--- a/brackets-prisma-db/src/storage-handlers/select-handlers/round.ts
+++ b/brackets-prisma-db/src/storage-handlers/select-handlers/round.ts
@@ -9,7 +9,9 @@ export async function handleRoundSelect(
     if (filter === undefined) {
         // Query all entries of table
         return prisma.round
-            .findMany()
+            .findMany({
+                orderBy: [{ number: 'asc' }],
+            })
             .then((values) => values.map(RoundTransformer.from))
             .catch(() => []);
     }
@@ -38,6 +40,7 @@ export async function handleRoundSelect(
                 groupId: filter.group_id,
                 number: filter.number,
             },
+            orderBy: [{ number: 'asc' }],
         })
         .then((values) => values.map(RoundTransformer.from))
         .catch(() => []);

--- a/brackets-prisma-db/src/storage-handlers/select-handlers/stage.ts
+++ b/brackets-prisma-db/src/storage-handlers/select-handlers/stage.ts
@@ -14,6 +14,7 @@ export async function handleStageSelect(
                 include: {
                     settings: true,
                 },
+                orderBy: [{ number: 'asc' }],
             })
             .then((values) =>
                 values.map((value) => {
@@ -74,6 +75,7 @@ export async function handleStageSelect(
             include: {
                 settings: true,
             },
+            orderBy: [{ number: 'asc' }],
         })
         .then((values) =>
             values.map((value) => {


### PR DESCRIPTION
The `brackets-manager` requires things to be in sorted order by `number`.
Now every result will be also ordered.

Closes #6 