### PR TITLE
Upgrade Prisma to `5.4.2` and Brackets Manager to `1.6.4`

### DIFF
--- a/brackets-prisma-db/package.json
+++ b/brackets-prisma-db/package.json
@@ -28,21 +28,23 @@
         "sql"
     ],
     "scripts": {
+        "postinstall": "patch-package",
         "build": "tsc",
         "prepare": "npm run build",
         "prepublishOnly": "npm run build"
     },
     "dependencies": {
-        "@prisma/client": "^4.16.1",
-        "brackets-manager": "^1.5.8",
-        "brackets-model": "^1.4.0",
+        "@prisma/client": "^5.4.2",
+        "brackets-manager": "1.6.4",
+        "brackets-model": "^1.5.0",
         "typescript": "^5.1.3"
     },
     "devDependencies": {
         "@types/node": "^20.3.0",
-        "prisma": "^4.16.1"
+        "patch-package": "^8.0.0",
+        "prisma": "^5.4.2"
     },
     "peerDependencies": {
-        "brackets-manager": "^1.3.9"
+        "brackets-manager": "1.6.4"
     }
 }

--- a/brackets-prisma-db/patches/brackets-model+1.5.0.patch
+++ b/brackets-prisma-db/patches/brackets-model+1.5.0.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/brackets-model/dist/unions.d.ts b/node_modules/brackets-model/dist/unions.d.ts
+index 21e62a0..4f69151 100644
+--- a/node_modules/brackets-model/dist/unions.d.ts
++++ b/node_modules/brackets-model/dist/unions.d.ts
+@@ -33,4 +33,4 @@ export type Result = 'win' | 'draw' | 'loss';
+ /**
+  * Depending on your storage system, you might prefer strings or numbers.
+  */
+-export type Id = string | number;
++export type Id = number;


### PR DESCRIPTION
A patch using `patch-package` is needed for the `brackets-model` in order to work with the numeric Ids.

String Ids are not supported for now since there is no way to prevent Id types (`number` and `string`) from mixing. Maybe a generic for the Manager itself could prevent that?

Related Issue: #8 