### PR TITLE
[prisma] Use transaction to delete `StageSettings` first

### DIFF
--- a/brackets-prisma-db/src/storage-handlers/delete-handlers/stage.ts
+++ b/brackets-prisma-db/src/storage-handlers/delete-handlers/stage.ts
@@ -6,26 +6,48 @@ export async function handleStageDelete(
     prisma: PrismaClient,
     filter?: Partial<DataTypes['stage']>,
 ): Promise<boolean> {
-    // No filter so delete everything
-    if (!filter) {
-        return prisma.stage
-            .deleteMany({})
-            .then(() => true)
-            .catch(() => false);
-    }
+    return prisma
+        .$transaction(async (tx) => {
+            // Build where clause if a filter is provided
+            const where = filter
+                ? {
+                    id: filter.id,
+                    name: filter.name,
+                    number: filter.number,
+                    tournamentId: filter.tournament_id,
+                    type: filter.type
+                        ? StageTypeTransformer.to(filter.type)
+                        : undefined,
+                }
+                : undefined;
 
-    return prisma.stage
-        .deleteMany({
-            where: {
-                id: filter.id,
-                name: filter.name,
-                number: filter.number,
-                tournamentId: filter.tournament_id,
-                type: filter.type
-                    ? StageTypeTransformer.to(filter.type)
-                    : undefined,
-            },
+            if (!where) {
+                // No filter: delete in the right order to satisfy FK constraints
+                await tx.stageSettings.deleteMany({});
+                await tx.stage.deleteMany({});
+                return true;
+            }
+
+            // Filtered delete: find matching stages
+            const stages = await tx.stage.findMany({
+                where,
+                select: { id: true },
+            });
+
+            if (stages.length === 0) return true;
+
+            // Delete related StageSettings first to satisfy FK constraints
+            await tx.stageSettings.deleteMany({
+                where: { stageId: { in: stages.map((s) => s.id) } },
+            });
+
+            // Then delete the stages
+            await tx.stage.deleteMany({ where });
+            return true;
         })
         .then(() => true)
-        .catch(() => false);
+        .catch((e) => {
+            console.error(new Error(`Error deleting stages with filter ${JSON.stringify(filter)}`, { cause: e }));
+            return false;
+        });
 }


### PR DESCRIPTION
There is a foreign key from `Stage` to `StageSettings`, so in order to make `manager.delete.stage()` work we need to first delete `StageSettings` to avoid a constraint error.