### PR TITLE
[prisma] Rely on `brackets-manager` from `peerDependencies`

### DIFF
--- a/brackets-prisma-db/README.md
+++ b/brackets-prisma-db/README.md
@@ -31,8 +31,11 @@ Lastly push the definition to your database using `npx prisma db push`.
 
 ```typescript
 import { SqlDatabase } from 'brackets-prisma-db';
-import { prisma } from './client';
 import { BracketsManager } from 'brackets-manager';
+import { PrismaClient } from '@prisma/client'
+
+// Your Prisma client
+const prisma = new PrismaClient();
 
 const storage = new SqlDatabase(prisma);
 const manager = new BracketsManager(storage);

--- a/brackets-prisma-db/package.json
+++ b/brackets-prisma-db/package.json
@@ -1,7 +1,7 @@
 {
     "name": "brackets-prisma-db",
     "version": "1.0.2",
-    "description": "A sql database with prisma for brackets-manager.js",
+    "description": "A SQL database with Prisma for brackets-manager.js",
     "author": "Tandashi",
     "license": "ISC",
     "repository": {

--- a/brackets-prisma-db/package.json
+++ b/brackets-prisma-db/package.json
@@ -34,7 +34,6 @@
     },
     "dependencies": {
         "@prisma/client": "^6.17.1",
-        "brackets-manager": "1.5.10",
         "brackets-model": "1.4.0",
         "typescript": "^5.1.3"
     },


### PR DESCRIPTION
This PR removes the explicit dep in favor of the peer dep, to avoid having two versions of the manager in the same project.

The storage implementation only relies on types from the manager, and they are less subject to change.